### PR TITLE
Switch logging to log4rs and add asynchronous logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MaidSafe Utilities - Change Log
 
+## [0.4.1]
+- Use bincode serialisation size limits
+
 ## [0.4.0]
 - Changed from using CBOR to Bincode.
 - Disabled Clippy warning.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "maidsafe_utilities"
 readme = "README.md"
 repository = "https://github.com/maidsafe/maidsafe_utilities"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 bincode = "~0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,11 @@ version = "0.4.1"
 [dependencies]
 bincode = "~0.5.1"
 clippy = {version = "~0.0.54", optional = true}
-env_logger = "~0.3.2"
 log = "~0.3.5"
+log4rs = "~0.3.3"
 rustc-serialize = "~0.3.18"
-time = "~0.1.34"
+toml = "~0.1.28"
 quick-error = "1.0.0"
+
+[dev-dependencies]
+time = "~0.1.34"

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+extern crate maidsafe_utilities;
+#[macro_use]
+extern crate log as logger;
+
+use maidsafe_utilities::log;
+
+fn main() {
+  log::init(true);
+
+  trace!("Hello world");
+  debug!("Hello world");
+  info!("Hello world");
+  warn!("Hello world");
+  error!("Hello world");
+}

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -23,6 +23,7 @@ use maidsafe_utilities::log;
 
 fn main() {
   log::init(true);
+  // let _ = log::init_to_file_async(true, "main.log", true);
 
   trace!("Hello world");
   debug!("Hello world");

--- a/examples/log.toml
+++ b/examples/log.toml
@@ -12,6 +12,11 @@ kind = "async_console"
 kind = "async_file"
 path = "main.log"
 
+[appender.async_server]
+level = "info"
+kind = "async_server"
+server_addr = "127.0.0.1:40000"
+
 [root]
 level = "trace"
 appenders = ["console"]

--- a/examples/log.toml
+++ b/examples/log.toml
@@ -1,0 +1,23 @@
+[appender.console]
+kind = "console"
+
+[appender.file]
+kind = "file"
+path = "main.log"
+
+[appender.async_console]
+kind = "async_console"
+
+[appender.async_file]
+kind = "async_file"
+path = "main.log"
+
+[root]
+level = "trace"
+appenders = ["console"]
+
+# Per module logging rules
+[[logger]]
+name = "foo::bar::baz"
+level = "warn"
+appenders = ["file"]

--- a/src/async_log.rs
+++ b/src/async_log.rs
@@ -236,7 +236,6 @@ impl SyncWrite for File {
 impl SyncWrite for TcpStream {
     fn sync_write(&mut self, buf: &[u8]) -> io::Result<()> {
         let _ = try!(self.write_all(buf));
-        println!("Written");
         Ok(())
     }
 }

--- a/src/async_log.rs
+++ b/src/async_log.rs
@@ -1,0 +1,214 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+// TODO: consider contributing this code to the log4rs crate.
+
+use log4rs::Append;
+use log4rs::pattern::PatternLayout;
+use log4rs::toml::CreateAppender;
+use logger::LogRecord;
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Stdout, Write};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Sender};
+use std::thread;
+use toml::{Table, Value};
+
+/// Appender that writes to the stdout asynchronously.
+pub struct AsyncConsoleAppender;
+
+impl AsyncConsoleAppender {
+    pub fn builder() -> AsyncConsoleAppenderBuilder {
+        AsyncConsoleAppenderBuilder { pattern: PatternLayout::default() }
+    }
+}
+
+pub struct AsyncConsoleAppenderBuilder {
+    pattern: PatternLayout,
+}
+
+impl AsyncConsoleAppenderBuilder {
+    pub fn pattern(self, pattern: PatternLayout) -> Self {
+        AsyncConsoleAppenderBuilder { pattern: pattern }
+    }
+
+    pub fn build(self) -> AsyncAppender {
+        AsyncAppender::new(io::stdout(), self.pattern)
+    }
+}
+
+/// Appender that writes to a file asynchronously.
+pub struct AsyncFileAppender;
+
+impl AsyncFileAppender {
+    pub fn builder<P: AsRef<Path>>(path: P) -> AsyncFileAppenderBuilder {
+        AsyncFileAppenderBuilder {
+            path: path.as_ref().to_path_buf(),
+            pattern: PatternLayout::default(),
+            append: true
+        }
+    }
+}
+
+pub struct AsyncFileAppenderBuilder {
+    path: PathBuf,
+    pattern: PatternLayout,
+    append: bool,
+}
+
+impl AsyncFileAppenderBuilder {
+    pub fn pattern(self, pattern: PatternLayout) -> Self {
+        AsyncFileAppenderBuilder {
+            path: self.path,
+            pattern: pattern,
+            append: self.append,
+        }
+    }
+
+    pub fn append(self, append: bool) -> Self {
+        AsyncFileAppenderBuilder {
+            path: self.path,
+            pattern: self.pattern,
+            append: append,
+        }
+    }
+
+    pub fn build(self) -> io::Result<AsyncAppender> {
+        let file = try!(OpenOptions::new().write(true)
+                                          .append(self.append)
+                                          .create(true)
+                                          .open(self.path));
+
+        Ok(AsyncAppender::new(file, self.pattern))
+    }
+}
+
+/// Creator for AsyncConsoleAppender
+pub struct AsyncConsoleAppenderCreator;
+
+impl CreateAppender for AsyncConsoleAppenderCreator {
+    fn create_appender(&self, mut config: Table) -> Result<Box<Append>, Box<Error>> {
+        let pattern = try!(parse_pattern(&mut config));
+        Ok(Box::new(AsyncConsoleAppender::builder().pattern(pattern).build()))
+    }
+}
+
+/// Creator for AsyncFileAppender
+pub struct AsyncFileAppenderCreator;
+
+impl CreateAppender for AsyncFileAppenderCreator {
+    fn create_appender(&self, mut config: Table) -> Result<Box<Append>, Box<Error>> {
+        let path = match config.remove("path") {
+            Some(Value::String(path)) => path,
+            Some(_) => return Err(Box::new(ConfigError("`path` must be a string".to_string()))),
+            None => return Err(Box::new(ConfigError("`path` is required".to_string()))),
+        };
+
+        let append = match config.remove("append") {
+            Some(Value::Boolean(append)) => append,
+            Some(_) => return Err(Box::new(ConfigError("`append` must be a bool".to_string()))),
+            None => true,
+        };
+
+        let pattern = try!(parse_pattern(&mut config));
+        let appender = try!(AsyncFileAppender::builder(path)
+                                              .pattern(pattern)
+                                              .append(append)
+                                              .build());
+
+        Ok(Box::new(appender))
+    }
+}
+
+fn parse_pattern(config: &mut Table) -> Result<PatternLayout, Box<Error>> {
+    match config.remove("pattern") {
+        Some(Value::String(pattern)) => Ok(try!(PatternLayout::new(&pattern))),
+        Some(_) => return Err(Box::new(ConfigError("`pattern` must be a string".to_string()))),
+        None => Ok(PatternLayout::default()),
+    }
+}
+
+#[derive(Debug)]
+struct ConfigError(String);
+
+impl Error for ConfigError {
+    fn description(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for ConfigError {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        fmt.write_str(&self.0)
+    }
+}
+
+pub struct AsyncAppender {
+    pattern: PatternLayout,
+    sender: Sender<Vec<u8>>,
+}
+
+impl AsyncAppender {
+    fn new<W: 'static + SyncWrite + Send>(mut writer: W, pattern: PatternLayout) -> Self {
+        let (sender, receiver) = mpsc::channel::<Vec<u8>>();
+
+        let _ = thread::spawn(move || {
+            for message in receiver.iter() {
+                // TODO: how should we handle errors here?
+                let _ = writer.sync_write(&message);
+            }
+        });
+
+        AsyncAppender {
+            pattern: pattern,
+            sender: sender,
+        }
+    }
+}
+
+impl Append for AsyncAppender {
+    fn append(&mut self, record: &LogRecord) -> Result<(), Box<Error>> {
+        let mut message = Vec::new();
+        try!(self.pattern.append(&mut message, record));
+        try!(self.sender.send(message));
+        Ok(())
+    }
+}
+
+trait SyncWrite {
+  fn sync_write(&mut self, buf: &[u8]) -> io::Result<()>;
+}
+
+impl SyncWrite for Stdout {
+  fn sync_write(&mut self, buf: &[u8]) -> io::Result<()> {
+    let mut out = self.lock();
+    try!(out.write_all(buf));
+    try!(out.flush());
+    Ok(())
+  }
+}
+
+impl SyncWrite for File {
+  fn sync_write(&mut self, buf: &[u8]) -> io::Result<()> {
+    try!(self.write_all(buf));
+    try!(self.flush());
+    Ok(())
+  }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,9 @@
 #![cfg_attr(feature="clippy", allow(use_debug))]
 
 extern crate bincode;
-extern crate env_logger;
+extern crate log4rs;
 extern crate rustc_serialize;
-extern crate time;
+extern crate toml;
 #[macro_use]
 extern crate log as logger;
 
@@ -57,7 +57,7 @@ extern crate quick_error;
 #[macro_use] mod unwrap;
 
 /// Utilities related to threading.
-#[macro_use]pub mod thread;
+#[macro_use] pub mod thread;
 
 /// Allows initialising the env_logger with a standard message format.
 pub mod log;
@@ -65,3 +65,5 @@ pub mod log;
 pub mod event_sender;
 /// Functions for serialisation and deserialisation
 pub mod serialisation;
+
+mod async_log;

--- a/src/log.rs
+++ b/src/log.rs
@@ -15,7 +15,6 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-//!
 //! These functions can initialise the env_logger for output to stderr only, or to a file and
 //! stderr.
 //!
@@ -66,29 +65,52 @@
 //! }
 //! ```
 
-#![allow(unused)]
-use std::env;
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::thread;
+use log4rs;
+use log4rs::appender::{ConsoleAppender, FileAppender};
+use log4rs::config::{Appender, Config, Root};
+use log4rs::pattern::PatternLayout;
+use log4rs::toml::Creator;
 
-use env_logger::LogBuilder;
-use logger::{LogLevel, LogRecord};
-use time;
+use std::path::Path;
+use std::sync::{Once, ONCE_INIT};
 
-static INITIALISE_LOGGER: ::std::sync::Once = ::std::sync::ONCE_INIT;
+use async_log::{AsyncConsoleAppenderCreator, AsyncFileAppenderCreator};
+use logger::LogLevelFilter;
 
-/// Initialises the env_logger for output to stderr.
+static INITIALISE_LOGGER: Once = ONCE_INIT;
+static CONFIG_FILE: &'static str = "log.toml";
+
+/// Initialises the env_logger for output to stdout.
 ///
 /// For further details, see the [module docs](index.html).
 pub fn init(show_thread_name: bool) {
     INITIALISE_LOGGER.call_once(|| {
-        build(move |record: &LogRecord| format_record(show_thread_name, record));
+        let config_path = Path::new(CONFIG_FILE);
+
+        if config_path.is_file() {
+            let mut creator = Creator::default();
+            creator.add_appender("async_console", Box::new(AsyncConsoleAppenderCreator));
+            creator.add_appender("async_file", Box::new(AsyncFileAppenderCreator));
+
+            log4rs::init_file(config_path, creator)
+        } else {
+            let pattern = make_pattern(show_thread_name);
+
+            let appender = ConsoleAppender::builder().pattern(pattern).build();
+            let appender = Appender::builder("console".to_owned(), Box::new(appender)).build();
+
+            let root = Root::builder(LogLevelFilter::Trace).appender("console".to_owned()).build();
+            let config = Config::builder(root).appender(appender).build().unwrap();
+
+            // TODO: add loggers by parsing RUST_LOG env variable.
+
+            log4rs::init_config(config)
+        }
+        .expect("failed to initialize logging");
     });
 }
 
-/// Initialises the env_logger for output to a file and to stderr.
+/// Initialises the env_logger for output to a file and to stdout.
 ///
 /// This function will create the logfile at `file_path` if it does not exist, and will truncate it
 /// if it does.  For further details, see the [module docs](index.html).
@@ -104,93 +126,60 @@ pub fn init(show_thread_name: bool) {
 ///     assert!(maidsafe_utilities::log::init_to_file(true, "target/test.log").is_ok());
 ///     error!("An error!");
 ///     assert_eq!(maidsafe_utilities::log::init_to_file(true, "target/test.log").unwrap_err(),
-///         "Logger already initialised.".to_owned());
+///         "Logger already initialised".to_owned());
 ///
 ///     // E 22:38:05.499016 <main> [example:main.rs:7] An error!
 /// }
 /// ```
 pub fn init_to_file<P: AsRef<Path>>(show_thread_name: bool, file_path: P) -> Result<(), String> {
-    let mut result = Err("Logger already initialised.".to_owned());
-    let filepath: PathBuf = file_path.as_ref().to_owned();
+    let mut result = Err("Logger already initialised".to_owned());
+
     INITIALISE_LOGGER.call_once(|| {
-        // Check the file can be created in the initialisation phase rather than waiting until the
-        // first call to a logging macro.  If the file can't be created, fall back to stderr logging
-        // only and return an `Err`.
-        let _ = fs::remove_file(&filepath);
-        match File::create(&filepath) {
-            Ok(_) => {
-                result = Ok(());
-                let format = move |record: &LogRecord| {
-                    let mut log_message = format_record(show_thread_name, record);
-                    log_message.push('\n');
-                    let mut logfile = unwrap_result!(OpenOptions::new()
-                                                         .write(true)
-                                                         .create(true)
-                                                         .append(true)
-                                                         .open(&filepath));
-                    unwrap_result!(logfile.write_all(&log_message.clone().into_bytes()[..]));
-                    let _ = log_message.pop();
-                    log_message
-                };
-                build(format);
-            }
+        let file_appender = FileAppender::builder(file_path)
+                                .pattern(make_pattern(show_thread_name))
+                                .append(false)
+                                .build();
+        let file_appender = match file_appender {
+            Ok(appender) => appender,
             Err(error) => {
-                result = Err(format!("Failed to create logfile at {} - {}",
-                                     filepath.display(),
-                                     error));
-                build(move |record: &LogRecord| format_record(show_thread_name, record));
+                result = Err(format!("{}", error));
+                return;
             }
         };
+        let file_appender = Appender::builder("file".to_owned(), Box::new(file_appender)).build();
+
+        let console_appender = ConsoleAppender::builder()
+                                   .pattern(make_pattern(show_thread_name))
+                                   .build();
+        let console_appender = Appender::builder("console".to_owned(), Box::new(console_appender))
+                                   .build();
+
+        let root = Root::builder(LogLevelFilter::Trace)
+                       .appender("console".to_owned())
+                       .appender("file".to_owned())
+                       .build();
+
+        let config = Config::builder(root)
+                         .appender(console_appender)
+                         .appender(file_appender)
+                         .build()
+                         .unwrap();
+
+        // TODO: add loggers by parsing RUST_LOG env variable.
+
+        result = log4rs::init_config(config).map_err(|e| format!("{}", e))
     });
+
     result
 }
 
-fn format_record(show_thread_name: bool, record: &LogRecord) -> String {
-    let now = time::now();
-    let mut thread_name = "".to_owned();
-    if show_thread_name {
-        thread_name = thread::current().name().unwrap_or("???").to_owned();
-        thread_name.push_str(" ");
-    }
-    let src_filename_length = record.location().file().len();
-    let src_file = if src_filename_length > 40 {
-        let mut src_file = "...".to_owned();
-        src_file.push_str(&record.location().file()[(src_filename_length - 40)..src_filename_length]);
-        src_file
+
+fn make_pattern(show_thread_name: bool) -> PatternLayout {
+    let pattern = if show_thread_name {
+        "%l %T [%M:%f:%L] %m"
     } else {
-        record.location().file().to_owned()
+        "%l [%M:%f:%L] %m"
     };
 
-    format!("{} {}.{:06} {}[{}:{}:{}] {}",
-            match record.level() {
-                LogLevel::Error => 'E',
-                LogLevel::Warn => 'W',
-                LogLevel::Info => 'I',
-                LogLevel::Debug => 'D',
-                LogLevel::Trace => 'T',
-            },
-            if let Ok(time_txt) = ::time::strftime("%T", &now) {
-                time_txt
-            } else {
-                "".to_owned()
-            },
-            now.tm_nsec / 1000,
-            thread_name,
-            record.location().module_path().splitn(2, "::").next().unwrap_or(""),
-            src_file,
-            record.location().line(),
-            record.args())
-}
-
-fn build<F: 'static>(format: F)
-    where F: Fn(&LogRecord) -> String + Sync + Send
-{
-    let mut builder = LogBuilder::new();
-    let _ = builder.format(format);
-
-    if let Ok(rust_log) = env::var("RUST_LOG") {
-        let _ = builder.parse(&rust_log);
-    }
-
-    builder.init().unwrap_or_else(|error| println!("Error initialising logger: {}", error));
+    PatternLayout::new(pattern).unwrap()
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -78,7 +78,7 @@ use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 use std::sync::{Once, ONCE_INIT};
 
-use async_log::{AsyncConsoleAppenderCreator, AsyncFileAppenderCreator};
+use async_log::{AsyncConsoleAppenderCreator, AsyncFileAppenderCreator, AsyncServerAppenderCreator};
 use logger::LogLevelFilter;
 
 static INITIALISE_LOGGER: Once = ONCE_INIT;
@@ -96,6 +96,7 @@ pub fn init(show_thread_name: bool) {
             let mut creator = Creator::default();
             creator.add_appender("async_console", Box::new(AsyncConsoleAppenderCreator));
             creator.add_appender("async_file", Box::new(AsyncFileAppenderCreator));
+            creator.add_appender("async_server", Box::new(AsyncServerAppenderCreator));
 
             log4rs::init_file(config_path, creator)
         } else {
@@ -108,10 +109,10 @@ pub fn init(show_thread_name: bool) {
 
             let root = Root::builder(default_level).appender("console".to_owned()).build();
             let config = Config::builder(root)
-                            .appender(appender)
-                            .loggers(loggers)
-                            .build()
-                            .unwrap();
+                             .appender(appender)
+                             .loggers(loggers)
+                             .build()
+                             .unwrap();
 
             log4rs::init_config(config)
         }
@@ -160,8 +161,7 @@ pub fn init_to_file<P: AsRef<Path>>(show_thread_name: bool, file_path: P) -> Res
         let console_appender = ConsoleAppender::builder()
                                    .pattern(make_pattern(show_thread_name))
                                    .build();
-        let console_appender = Appender::builder("console".to_owned(), Box::new(console_appender))
-                                   .build();
+        let console_appender = Appender::builder("console".to_owned(), Box::new(console_appender)).build();
 
         let (default_level, loggers) = match parse_loggers_from_env() {
             Ok((level, loggers)) => (level, loggers),
@@ -229,9 +229,10 @@ fn parse_loggers(input: &str) -> Result<(LogLevelFilter, Vec<Logger>), ParseLogg
     let mut loggers = Vec::new();
     let mut default_level = DEFAULT_LOG_LEVEL_FILTER;
 
-    for logger in input.split(',').map(str::trim)
-                                  .filter(|d| !d.is_empty())
-                                  .map(parse_logger) {
+    for logger in input.split(',')
+                       .map(str::trim)
+                       .filter(|d| !d.is_empty())
+                       .map(parse_logger) {
         let logger = try!(logger);
 
         if logger.name().is_empty() {
@@ -263,7 +264,7 @@ fn parse_logger(input: &str) -> Result<Logger, ParseLoggerError> {
 
 #[cfg(test)]
 mod tests {
-    use ::logger::LogLevelFilter;
+    use logger::LogLevelFilter;
     use super::parse_loggers;
 
     #[test]

--- a/src/log.rs
+++ b/src/log.rs
@@ -15,8 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-//! These functions can initialise the env_logger for output to stderr only, or to a file and
-//! stderr.
+//! These functions can initialise logging for output to stdout only, or to a file and
+//! stdout. For more fine-grained control, create file called `log.toml` in the root
+//! directory of the project, or in the same directory where the executable is.
+//! See http://sfackler.github.io/log4rs/doc/v0.3.3/log4rs/index.html for details
+//! about format and structure of this file.
 //!
 //! An example of a log message is:
 //!
@@ -79,6 +82,7 @@ use logger::LogLevelFilter;
 
 static INITIALISE_LOGGER: Once = ONCE_INIT;
 static CONFIG_FILE: &'static str = "log.toml";
+static DEFAULT_LOG_LEVEL_FILTER: LogLevelFilter = LogLevelFilter::Warn;
 
 /// Initialises the env_logger for output to stdout.
 ///
@@ -99,7 +103,7 @@ pub fn init(show_thread_name: bool) {
             let appender = ConsoleAppender::builder().pattern(pattern).build();
             let appender = Appender::builder("console".to_owned(), Box::new(appender)).build();
 
-            let root = Root::builder(LogLevelFilter::Trace).appender("console".to_owned()).build();
+            let root = Root::builder(DEFAULT_LOG_LEVEL_FILTER).appender("console".to_owned()).build();
             let config = Config::builder(root).appender(appender).build().unwrap();
 
             // TODO: add loggers by parsing RUST_LOG env variable.
@@ -154,7 +158,7 @@ pub fn init_to_file<P: AsRef<Path>>(show_thread_name: bool, file_path: P) -> Res
         let console_appender = Appender::builder("console".to_owned(), Box::new(console_appender))
                                    .build();
 
-        let root = Root::builder(LogLevelFilter::Trace)
+        let root = Root::builder(DEFAULT_LOG_LEVEL_FILTER)
                        .appender("console".to_owned())
                        .appender("file".to_owned())
                        .build();

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -73,7 +73,7 @@ mod test {
     use super::*;
     use std::thread;
     use std::time::Duration;
-    use time::SteadyTime;
+    use self::time::SteadyTime;
 
     #[test]
     fn raii_thread_joiner() {


### PR DESCRIPTION
This PR changes the logging library from [env_logger](https://crates.io/crates/env_logger) to [log4rs](https://crates.io/crates/log4rs) and introduces asynchronous logging.

Logging is now configured using `log.toml` file which must be placed in the project root, or in the same directory as the executable it applies to. See http://sfackler.github.io/log4rs/doc/v0.3.3/log4rs/ for more info about this file. 

If no `log.toml` file is present, the logger will default to a configuration similar to what used to be in place before this PR. ~~Main difference is that the `RUST_LOG` env variable is currently ignored and the log level defaults to trace. If this is not desirable, use `log.toml` to override it.~~ `RUST_LOG` is supported now.

Two additional appenders are available, in addition to what `log4rs` provides by default: `async_console` and `async_file`. They are the same as the corresponding `console` and `file` appenders from `log4rs`, except the actual writing is performed asynchronously, in a background thread. This should provide performance advantage in apps that use logging heavily (no benchmarks were performed to confirm this though).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/37)

<!-- Reviewable:end -->
