### PR TITLE
fix/logging: use ISO format for date & time

### DIFF
--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -370,7 +370,7 @@ fn make_pattern(show_thread_name: bool) -> PatternLayout {
 }
 
 fn make_json_pattern(unique_id: u64) -> PatternLayout {
-    let pattern = format!("{{\"id\":{},\"level\":\"%l\",\"time\":\"%d\",\"thread\":\"%T\",\
+    let pattern = format!("{{\"id\":\"{}\",\"level\":\"%l\",\"time\":\"%d\",\"thread\":\"%T\",\
                            \"module\":\"%M\",\"file\":\"%f\",\"line\":\"%L\",\"msg\":\"%m\"}}",
                           unique_id);
 

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -370,9 +370,8 @@ fn make_pattern(show_thread_name: bool) -> PatternLayout {
 }
 
 fn make_json_pattern(unique_id: u64) -> PatternLayout {
-    let pattern = format!("{{\"id\":{},\"level\":\"%l\",\"time\":\"%d{{%H:%M:%S.%f}}\",\
-                           \"thread\":\"%T\",\"module\":\"%M\",\"file\":\"%f\",\"line\":\"%L\",\
-                           \"msg\":\"%m\"}}",
+    let pattern = format!("{{\"id\":{},\"level\":\"%l\",\"time\":\"%d\",\"thread\":\"%T\",\
+                           \"module\":\"%M\",\"file\":\"%f\",\"line\":\"%L\",\"msg\":\"%m\"}}",
                           unique_id);
 
     unwrap_result!(PatternLayout::new(&pattern))


### PR DESCRIPTION
Logs to web-server will come from different machines situated in different time zones. The previous code sent local machine's time which is not very useful for Web-Servers. This code fixes that by making sure ISO format with UTC offset is used

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/53)

<!-- Reviewable:end -->
