### PR TITLE
fix/logging: put default json pattern

### DIFF
--- a/examples/log.rs
+++ b/examples/log.rs
@@ -20,15 +20,19 @@ extern crate maidsafe_utilities;
 #[macro_use]
 extern crate log as logger;
 
+use std::thread;
+use std::time::Duration;
 use maidsafe_utilities::log;
 
 fn main() {
     unwrap_result!(log::init(true));
-    // let _ = log::init_to_file_async(true, "main.log", true);
 
     trace!("Hello world");
     debug!("Hello world");
     info!("Hello world");
     warn!("Hello world");
     error!("Hello world");
+
+    // Give some time to the async logger to complete
+    thread::sleep(Duration::from_millis(100));
 }

--- a/examples/log.toml
+++ b/examples/log.toml
@@ -1,28 +1,15 @@
-[appender.console]
-kind = "console"
-
-[appender.file]
-kind = "file"
-path = "main.log"
-
-[appender.async_console]
-kind = "async_console"
+#[appender.async_console]
+#kind = "async_console"
 
 [appender.async_file]
 kind = "async_file"
 path = "main.log"
 
-[appender.async_server]
-level = "info"
-kind = "async_server"
-server_addr = "127.0.0.1:40000"
+[appender.aysnc_web_socket]
+kind = "async_web_socket"
+server_url = "ws://127.0.0.1:59697"
 
 [root]
 level = "trace"
-appenders = ["console"]
-
-# Per module logging rules
-[[logger]]
-name = "foo::bar::baz"
-level = "warn"
-appenders = ["file"]
+appenders = ["async_web_socket", "async_file"]
+#appenders = ["async_web_socket", "async_file", "async_console"]

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -321,7 +321,7 @@ pub fn init_to_web_socket<U: Borrow<str>>(server_url: U,
         let mut config = Config::builder(root).loggers(loggers);
 
         let server_appender = match AsyncWebSockAppender::builder(server_url)
-                                        .pattern(make_json_pattern(rand::random()))
+                                        .pattern(async_log::make_json_pattern(rand::random()))
                                         .build()
                                         .map_err(|e| format!("{}", e)) {
             Ok(appender) => appender,
@@ -367,14 +367,6 @@ fn make_pattern(show_thread_name: bool) -> PatternLayout {
     };
 
     unwrap_result!(PatternLayout::new(pattern))
-}
-
-fn make_json_pattern(unique_id: u64) -> PatternLayout {
-    let pattern = format!("{{\"id\":\"{}\",\"level\":\"%l\",\"time\":\"%d\",\"thread\":\"%T\",\
-                           \"module\":\"%M\",\"file\":\"%f\",\"line\":\"%L\",\"msg\":\"%m\"}}",
-                          unique_id);
-
-    unwrap_result!(PatternLayout::new(&pattern))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
- When no pattern is specified in the log.toml file for websocket, default to the json pattern, also used by command line args, and incorporate random id therein
- Add sample log.toml file for demo-ing web-socket log enabling

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/55)

<!-- Reviewable:end -->
