### PR TITLE
feat/sip_hash: add a new endian-agnostic Sip hash function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ repository = "https://github.com/maidsafe/maidsafe_utilities"
 version = "0.5.4"
 
 [dependencies]
-bincode = "~0.5.1"
-clippy = {version = "~0.0.63", optional = true}
+bincode = "~0.5.6"
+clippy = {version = "~0.0.68", optional = true}
 log = "~0.3.6"
 log4rs = "~0.3.3"
 net2 = "~0.2.23"
 quick-error = "1.0.0"
 rand = "~0.3.14"
-regex = "~0.1.62"
+regex = "~0.1.70"
 rustc-serialize = "~0.3.19"
-toml = "~0.1.28"
-ws = "~0.4.6"
+toml = "~0.1.30"
+ws = "~0.4.7"

--- a/src/big_endian_sip_hash.rs
+++ b/src/big_endian_sip_hash.rs
@@ -1,0 +1,45 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use std::hash::{Hasher, SipHasher};
+
+use bincode::{self, SizeLimit};
+use rustc_serialize::Encodable;
+
+/// Generates a deterministic Sip hash from `data`, regardless of the endianness of the host
+/// machine.
+pub fn big_endian_sip_hash<T: Encodable>(data: &T) -> u64 {
+    let encoded = bincode::rustc_serialize::encode(data, SizeLimit::Infinite).unwrap_or(vec![]);
+    let mut hasher = SipHasher::new();
+    hasher.write(&encoded);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_test() {
+        assert_eq!(4363127275821894810, big_endian_sip_hash(&"Test".to_owned()));
+        assert_eq!(4752125029563925438, big_endian_sip_hash(&[24u64, 6, 1314]));
+        let mut option = Some(1);
+        assert_eq!(17848574548716743387, big_endian_sip_hash(&option));
+        option = None;
+        assert_eq!(10041351145189524877, big_endian_sip_hash(&option));
+    }
+}

--- a/src/event_sender.rs
+++ b/src/event_sender.rs
@@ -155,8 +155,7 @@ impl<Category: fmt::Debug + Clone, EventSubset: fmt::Debug> EventSender<Category
 // it requires EventSubset to be clonable even though mpsc::Sender<EventSubset> does
 // not require EventSubset to be clonable for itself being cloned.
 impl<Category: fmt::Debug + Clone, EventSubset: fmt::Debug> Clone for EventSender<Category,
-                                                                                  EventSubset>
-    {
+                                                                                  EventSubset> {
     fn clone(&self) -> EventSender<Category, EventSubset> {
         EventSender {
             event_tx: self.event_tx.clone(),
@@ -217,9 +216,8 @@ mod test {
                                                  EventCategory::UserInterface,
                                                  category_tx.clone());
 
-        let nw_event_sender = NetworkEventSender::new(network_event_tx,
-                                                      EventCategory::Network,
-                                                      category_tx);
+        let nw_event_sender =
+            NetworkEventSender::new(network_event_tx, EventCategory::Network, category_tx);
 
         let joiner = thread!("EventListenerThread", move || {
             for it in category_rx.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,21 +43,20 @@
 #![cfg_attr(feature="clippy", deny(clippy, clippy_pedantic))]
 #![cfg_attr(feature="clippy", allow(use_debug))]
 
-extern crate net2;
 extern crate bincode;
-extern crate log4rs;
-extern crate rustc_serialize;
-extern crate toml;
 #[macro_use]
 extern crate log as logger;
-extern crate rand;
-extern crate regex;
-extern crate ws;
-
+extern crate log4rs;
+extern crate net2;
 #[allow(unused_extern_crates)]
 // Needed because the crate is only used for macros
 #[macro_use]
 extern crate quick_error;
+extern crate rand;
+extern crate regex;
+extern crate rustc_serialize;
+extern crate toml;
+extern crate ws;
 
 #[macro_use]
 mod unwrap;
@@ -65,10 +64,12 @@ mod unwrap;
 /// Utilities related to threading.
 #[macro_use]
 pub mod thread;
-
-/// Allows initialising the `env_logger` with a standard message format.
-pub mod log;
+mod big_endian_sip_hash;
 /// Utilities related to event-subsetting.
 pub mod event_sender;
+/// Allows initialising the `env_logger` with a standard message format.
+pub mod log;
 /// Functions for serialisation and deserialisation
 pub mod serialisation;
+
+pub use big_endian_sip_hash::big_endian_sip_hash;

--- a/src/log/async_log.rs
+++ b/src/log/async_log.rs
@@ -101,10 +101,10 @@ impl AsyncFileAppenderBuilder {
 
     pub fn build(self) -> io::Result<AsyncAppender> {
         let file = try!(OpenOptions::new()
-                            .write(true)
-                            .append(self.append)
-                            .create(true)
-                            .open(self.path));
+            .write(true)
+            .append(self.append)
+            .create(true)
+            .open(self.path));
 
         Ok(AsyncAppender::new(file, self.pattern))
     }
@@ -211,9 +211,9 @@ impl CreateAppender for AsyncFileAppenderCreator {
 
         let pattern = try!(parse_pattern(&mut config, false));
         let appender = try!(AsyncFileAppender::builder(path)
-                                .pattern(pattern)
-                                .append(append)
-                                .build());
+            .pattern(pattern)
+            .append(append)
+            .build());
 
         Ok(Box::new(appender))
     }
@@ -238,9 +238,9 @@ impl CreateAppender for AsyncServerAppenderCreator {
         let pattern = try!(parse_pattern(&mut config, false));
 
         Ok(Box::new(try!(AsyncServerAppender::builder(server_addr)
-                             .pattern(pattern)
-                             .no_delay(no_delay)
-                             .build())))
+            .pattern(pattern)
+            .no_delay(no_delay)
+            .build())))
     }
 }
 
@@ -258,8 +258,8 @@ impl CreateAppender for AsyncWebSockAppenderCreator {
         let pattern = try!(parse_pattern(&mut config, true));
 
         Ok(Box::new(try!(AsyncWebSockAppender::builder(server_url)
-                             .pattern(pattern)
-                             .build())))
+            .pattern(pattern)
+            .build())))
     }
 }
 

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -128,21 +128,20 @@ pub fn init(show_thread_name: bool) -> Result<(), String> {
             log4rs::init_file(config_path, creator).map_err(|e| format!("{}", e))
         } else {
             let console_appender = AsyncConsoleAppender::builder()
-                                       .pattern(make_pattern(show_thread_name))
-                                       .build();
-            let console_appender = Appender::builder("async_console".to_owned(),
-                                                     Box::new(console_appender))
-                                       .build();
+                .pattern(make_pattern(show_thread_name))
+                .build();
+            let console_appender =
+                Appender::builder("async_console".to_owned(), Box::new(console_appender)).build();
 
             let (default_level, loggers) = parse_loggers_from_env()
-                                               .expect("failed to parse RUST_LOG env variable");
+                .expect("failed to parse RUST_LOG env variable");
 
             let root = Root::builder(default_level).appender("async_console".to_owned()).build();
             let config = match Config::builder(root)
-                                   .appender(console_appender)
-                                   .loggers(loggers)
-                                   .build()
-                                   .map_err(|e| format!("{}", e)) {
+                .appender(console_appender)
+                .loggers(loggers)
+                .build()
+                .map_err(|e| format!("{}", e)) {
                 Ok(config) => config,
                 Err(e) => {
                     result = Err(e);
@@ -186,9 +185,9 @@ pub fn init_to_file<P: AsRef<Path>>(show_thread_name: bool,
         let mut config = Config::builder(root).loggers(loggers);
 
         let file_appender = AsyncFileAppender::builder(file_path)
-                                .pattern(make_pattern(show_thread_name))
-                                .append(false)
-                                .build();
+            .pattern(make_pattern(show_thread_name))
+            .append(false)
+            .build();
         let file_appender = match file_appender {
             Ok(appender) => appender,
             Err(error) => {
@@ -202,11 +201,10 @@ pub fn init_to_file<P: AsRef<Path>>(show_thread_name: bool,
 
         if log_to_console {
             let console_appender = AsyncConsoleAppender::builder()
-                                       .pattern(make_pattern(show_thread_name))
-                                       .build();
-            let console_appender = Appender::builder("console".to_owned(),
-                                                     Box::new(console_appender))
-                                       .build();
+                .pattern(make_pattern(show_thread_name))
+                .build();
+            let console_appender =
+                Appender::builder("console".to_owned(), Box::new(console_appender)).build();
 
             config = config.appender(console_appender);
         }
@@ -254,9 +252,9 @@ pub fn init_to_server<A: ToSocketAddrs>(server_addr: A,
         let mut config = Config::builder(root).loggers(loggers);
 
         let server_appender = match AsyncServerAppender::builder(server_addr)
-                                        .pattern(make_pattern(show_thread_name))
-                                        .build()
-                                        .map_err(|e| format!("{}", e)) {
+            .pattern(make_pattern(show_thread_name))
+            .build()
+            .map_err(|e| format!("{}", e)) {
             Ok(appender) => appender,
             Err(e) => {
                 result = Err(e);
@@ -264,17 +262,16 @@ pub fn init_to_server<A: ToSocketAddrs>(server_addr: A,
             }
         };
         let server_appender = Appender::builder("server".to_owned(), Box::new(server_appender))
-                                  .build();
+            .build();
 
         config = config.appender(server_appender);
 
         if log_to_console {
             let console_appender = AsyncConsoleAppender::builder()
-                                       .pattern(make_pattern(show_thread_name))
-                                       .build();
-            let console_appender = Appender::builder("console".to_owned(),
-                                                     Box::new(console_appender))
-                                       .build();
+                .pattern(make_pattern(show_thread_name))
+                .build();
+            let console_appender =
+                Appender::builder("console".to_owned(), Box::new(console_appender)).build();
 
             config = config.appender(console_appender);
         }
@@ -323,9 +320,9 @@ pub fn init_to_web_socket<U: Borrow<str>>(server_url: U,
         let mut config = Config::builder(root).loggers(loggers);
 
         let server_appender = match AsyncWebSockAppender::builder(server_url)
-                                        .pattern(async_log::make_json_pattern(rand::random()))
-                                        .build()
-                                        .map_err(|e| format!("{}", e)) {
+            .pattern(async_log::make_json_pattern(rand::random()))
+            .build()
+            .map_err(|e| format!("{}", e)) {
             Ok(appender) => appender,
             Err(e) => {
                 result = Err(e);
@@ -333,17 +330,16 @@ pub fn init_to_web_socket<U: Borrow<str>>(server_url: U,
             }
         };
         let server_appender = Appender::builder("server".to_owned(), Box::new(server_appender))
-                                  .build();
+            .build();
 
         config = config.appender(server_appender);
 
         if log_to_console {
             let console_appender = AsyncConsoleAppender::builder()
-                                       .pattern(make_pattern(show_thread_name_in_console))
-                                       .build();
-            let console_appender = Appender::builder("console".to_owned(),
-                                                     Box::new(console_appender))
-                                       .build();
+                .pattern(make_pattern(show_thread_name_in_console))
+                .build();
+            let console_appender =
+                Appender::builder("console".to_owned(), Box::new(console_appender)).build();
 
             config = config.appender(console_appender);
         }
@@ -404,8 +400,8 @@ fn parse_loggers(input: &str) -> Result<(LogLevelFilter, Vec<Logger>), ParseLogg
     let mut default_level = DEFAULT_LOG_LEVEL_FILTER;
 
     for sub_input in input.split(',')
-                          .map(str::trim)
-                          .filter(|d| !d.is_empty()) {
+        .map(str::trim)
+        .filter(|d| !d.is_empty()) {
         let mut parts = sub_input.trim().split('=');
         match (parts.next(), parts.next()) {
             (Some(module_name), Some(level)) => {
@@ -550,7 +546,7 @@ mod test {
                     if found {
                         log_msgs.push(unwrap_result!(
                                 str::from_utf8(&read_buf[..search_frm_index]))
-                                          .to_owned());
+                            .to_owned());
                         read_buf = read_buf.split_off(search_frm_index + MSG_TERMINATOR.len());
                         search_frm_index = 0;
                     }
@@ -601,7 +597,7 @@ mod test {
             impl Handler for Server {
                 fn on_message(&mut self, msg: Message) -> ws::Result<()> {
                     assert!(unwrap_result!(msg.as_text())
-                                .contains(&format!("This is message {}", self.count)[..]));
+                        .contains(&format!("This is message {}", self.count)[..]));
                     self.count += 1;
                     if self.count == MSG_COUNT {
                         unwrap_result!(self.tx.send(()));

--- a/src/serialisation.rs
+++ b/src/serialisation.rs
@@ -114,9 +114,7 @@ mod test {
 
     #[test]
     fn serialise_deserialise() {
-        let original_data = (vec![0u8, 1, 3, 9],
-                             vec![-1i64, 888, -8765],
-                             "Some-String".to_owned());
+        let original_data = (vec![0u8, 1, 3, 9], vec![-1i64, 888, -8765], "Some-String".to_owned());
 
         let serialised_data = unwrap_result!(serialise(&original_data));
         let deserialised_data: (Vec<u8>, Vec<i64>, String) =
@@ -126,9 +124,7 @@ mod test {
 
     #[test]
     fn serialise_into_deserialise_from() {
-        let original_data = (vec![0u8, 1, 3, 9],
-                             vec![-1i64, 888, -8765],
-                             "Some-String".to_owned());
+        let original_data = (vec![0u8, 1, 3, 9], vec![-1i64, 888, -8765], "Some-String".to_owned());
         let mut serialised_data = vec![];
         unwrap_result!(serialise_into(&original_data, &mut serialised_data));
 


### PR DESCRIPTION
This implements a new Sip hash function which first serialises the input to big-endian bytes in
order to allow any given hash result to be identical regardless of the endianness of the host
machine.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/61)

<!-- Reviewable:end -->
