### PR TITLE
fix/test: fix Clippy lints and a bug that Clippy found, and remove MaidSafeEventCategory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ bincode = "~0.5.6"
 clippy = {version = "~0.0.68", optional = true}
 log = "~0.3.6"
 log4rs = "~0.3.3"
-net2 = "~0.2.23"
 quick-error = "1.0.0"
 rand = "~0.3.14"
 regex = "~0.1.70"

--- a/src/big_endian_sip_hash.rs
+++ b/src/big_endian_sip_hash.rs
@@ -23,7 +23,8 @@ use rustc_serialize::Encodable;
 /// Generates a deterministic Sip hash from `data`, regardless of the endianness of the host
 /// machine.
 pub fn big_endian_sip_hash<T: Encodable>(data: &T) -> u64 {
-    let encoded = bincode::rustc_serialize::encode(data, SizeLimit::Infinite).unwrap_or(vec![]);
+    let encoded =
+        bincode::rustc_serialize::encode(data, SizeLimit::Infinite).ok().unwrap_or_else(Vec::new);
     let mut hasher = SipHasher::new();
     hasher.write(&encoded);
     hasher.finish()

--- a/src/event_sender.rs
+++ b/src/event_sender.rs
@@ -118,6 +118,7 @@ pub enum EventSenderError<Category, EventSubset> {
 ///     assert!(ui_event_sender.send(UiEvent::CreateDirectory).is_ok());
 ///     assert!(ui_event_sender.send(UiEvent::Terminate).is_ok());
 /// # }
+#[derive(Clone, Debug)]
 pub struct EventSender<Category, EventSubset> {
     event_tx: mpsc::Sender<EventSubset>,
     event_category: Category,
@@ -150,32 +151,6 @@ impl<Category: fmt::Debug + Clone, EventSubset: fmt::Debug> EventSender<Category
         Ok(())
     }
 }
-
-// (Spandan) Need to manually implement this because the default derived one seems faulty in that
-// it requires EventSubset to be clonable even though mpsc::Sender<EventSubset> does
-// not require EventSubset to be clonable for itself being cloned.
-impl<Category: fmt::Debug + Clone, EventSubset: fmt::Debug> Clone for EventSender<Category,
-                                                                                  EventSubset> {
-    fn clone(&self) -> EventSender<Category, EventSubset> {
-        EventSender {
-            event_tx: self.event_tx.clone(),
-            event_category: self.event_category.clone(),
-            event_category_tx: self.event_category_tx.clone(),
-        }
-    }
-}
-
-/// Category of events meant for a MaidSafe observer listening to both, routing and crust events
-#[derive(Clone, Debug)]
-pub enum MaidSafeEventCategory {
-    /// Used by Crust to indicate a Crust Event has been fired
-    Crust,
-    /// Used by Routing to indicate a Routing Event has been fired
-    Routing,
-}
-
-/// Observer that Crust (and users of Routing if required) must allow to be registered
-pub type MaidSafeObserver<EventSubset> = EventSender<MaidSafeEventCategory, EventSubset>;
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,14 +40,14 @@
 
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
-#![cfg_attr(feature="clippy", deny(clippy, clippy_pedantic))]
-#![cfg_attr(feature="clippy", allow(use_debug))]
+#![cfg_attr(feature="clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
+                                   option_unwrap_used))]
+#![cfg_attr(feature="clippy", allow(use_debug, doc_markdown))]
 
 extern crate bincode;
 #[macro_use]
 extern crate log as logger;
 extern crate log4rs;
-extern crate net2;
 #[allow(unused_extern_crates)]
 // Needed because the crate is only used for macros
 #[macro_use]

--- a/src/log/async_log.rs
+++ b/src/log/async_log.rs
@@ -146,8 +146,6 @@ impl<A: ToSocketAddrs> AsyncServerAppenderBuilder<A> {
     }
 
     pub fn build(self) -> io::Result<AsyncAppender> {
-        use net2::TcpStreamExt;
-
         let stream = try!(TcpStream::connect(self.addr));
         try!(stream.set_nodelay(self.no_delay));
         Ok(AsyncAppender::new(stream, self.pattern))
@@ -384,7 +382,7 @@ impl SyncWrite for File {
 
 impl SyncWrite for TcpStream {
     fn sync_write(&mut self, buf: &[u8]) -> io::Result<()> {
-        let _ = try!(self.write_all(&buf));
+        try!(self.write_all(&buf));
         self.write_all(&MSG_TERMINATOR[..])
     }
 }

--- a/src/serialisation.rs
+++ b/src/serialisation.rs
@@ -185,12 +185,12 @@ mod test {
         assert_eq!(serialised_data, buffer);
 
         // Try to deserialise data above default limit with size limit specified
-        let deserialised_data_0 = unwrap_result!(deserialise_with_limit(&serialised_data,
+        let deserialised_data_0: Vec<u64> = unwrap_result!(deserialise_with_limit(&serialised_data,
                                                                         SizeLimit::Infinite));
-        let deserialised_data_1 =
+        assert_eq!(original_data, deserialised_data_0);
+        let deserialised_data_1: Vec<u64> =
             unwrap_result!(deserialise_from_with_limit(&mut Cursor::new(buffer),
                                                        SizeLimit::Infinite));
-
-        assert_eq!(deserialised_data_0, deserialised_data_1);
+        assert_eq!(original_data, deserialised_data_1);
     }
 }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -5,4 +5,4 @@ version = "0.0.1"
 
 [dependencies]
 log = "~0.3.6"
-maidsafe_utilities = "~0.5.4"
+maidsafe_utilities = "~0.6.0"


### PR DESCRIPTION
The `upper_limit` test actually compared `()` with `()` instead of the
deserialised vectors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/63)

<!-- Reviewable:end -->
