### PR TITLE
feat/sender_receiver: add event category back in

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 #![cfg_attr(feature="clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
                                    option_unwrap_used))]
-#![cfg_attr(feature="clippy", allow(use_debug, doc_markdown))]
+#![cfg_attr(feature="clippy", allow(use_debug, doc_markdown, useless_let_if_seq))]
 
 extern crate bincode;
 #[macro_use]


### PR DESCRIPTION
This will be revisited when the Crust API is changed to better match the
async approach.

Also, disable the new `useless_let_if_seq` Clippy lint for now, as it
has a false positive in `log::init_to_file`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/64)

<!-- Reviewable:end -->
