### PR TITLE
Make thread! into a function and rename it named

### DIFF
--- a/src/event_sender.rs
+++ b/src/event_sender.rs
@@ -89,7 +89,7 @@ pub enum EventSenderError<Category, EventSubset> {
 ///                                                   EventCategory::Network,
 ///                                                   category_tx);
 ///
-///     let joiner = thread!("EventListenerThread", move || {
+///     let _joiner = maidsafe_utilities::thread::named("EventListenerThread", move || {
 ///         for it in category_rx.iter() {
 ///             match it {
 ///                 EventCategory::Network => {
@@ -111,8 +111,6 @@ pub enum EventSenderError<Category, EventSubset> {
 ///             }
 ///         }
 ///     });
-///
-///     let _raii_joiner = maidsafe_utilities::thread::Joiner::new(joiner);
 ///
 ///     assert!(nw_event_sender.send(NetworkEvent::Connected).is_ok());
 ///     assert!(ui_event_sender.send(UiEvent::CreateDirectory).is_ok());
@@ -220,7 +218,7 @@ mod test {
         let nw_event_sender =
             NetworkEventSender::new(network_event_tx, EventCategory::Network, category_tx);
 
-        let joiner = thread!("EventListenerThread", move || {
+        let _joiner = ::thread::named("EventListenerThread", move || {
             for it in category_rx.iter() {
                 match it {
                     EventCategory::Network => {
@@ -244,8 +242,6 @@ mod test {
             }
         });
 
-        let _raii_joiner = ::thread::Joiner::new(joiner);
-
         assert!(nw_event_sender.send(NetworkEvent::Connected(TOKEN)).is_ok());
         assert!(ui_event_sender.send(UiEvent::CreateDirectory(DIR_NAME.to_string())).is_ok());
         assert!(ui_event_sender.send(UiEvent::Terminate).is_ok());
@@ -256,7 +252,7 @@ mod test {
         assert!(nw_event_sender.send(NetworkEvent::Disconnected).is_err());
 
         let result = ui_event_sender.send(UiEvent::CreateDirectory(DIR_NAME.to_owned())).err();
-        if let EventSenderError::EventSubset(send_err) = unwrap_option!(result, "") {
+        if let EventSenderError::EventSubset(send_err) = unwrap!(result) {
             if let UiEvent::CreateDirectory(dir_name) = send_err.0 {
                 assert_eq!(dir_name, DIR_NAME)
             } else {

--- a/src/event_sender.rs
+++ b/src/event_sender.rs
@@ -112,7 +112,7 @@ pub enum EventSenderError<Category, EventSubset> {
 ///         }
 ///     });
 ///
-///     let _raii_joiner = maidsafe_utilities::thread::RaiiThreadJoiner::new(joiner);
+///     let _raii_joiner = maidsafe_utilities::thread::Joiner::new(joiner);
 ///
 ///     assert!(nw_event_sender.send(NetworkEvent::Connected).is_ok());
 ///     assert!(ui_event_sender.send(UiEvent::CreateDirectory).is_ok());
@@ -244,7 +244,7 @@ mod test {
             }
         });
 
-        let _raii_joiner = ::thread::RaiiThreadJoiner::new(joiner);
+        let _raii_joiner = ::thread::Joiner::new(joiner);
 
         assert!(nw_event_sender.send(NetworkEvent::Connected(TOKEN)).is_ok());
         assert!(ui_event_sender.send(UiEvent::CreateDirectory(DIR_NAME.to_string())).is_ok());

--- a/src/log/async_log.rs
+++ b/src/log/async_log.rs
@@ -31,7 +31,7 @@ use std::net::{ToSocketAddrs, SocketAddr, TcpStream};
 
 use std::str::FromStr;
 use std::borrow::Borrow;
-use thread::RaiiThreadJoiner;
+use thread::Joiner;
 use log::web_socket::WebSocket;
 
 use regex::Regex;
@@ -308,7 +308,7 @@ enum AsyncEvent {
 pub struct AsyncAppender {
     pattern: PatternLayout,
     tx: Sender<AsyncEvent>,
-    _raii_joiner: RaiiThreadJoiner,
+    _raii_joiner: Joiner,
 }
 
 impl AsyncAppender {
@@ -341,7 +341,7 @@ impl AsyncAppender {
         AsyncAppender {
             pattern: pattern,
             tx: tx,
-            _raii_joiner: RaiiThreadJoiner::new(joiner),
+            _raii_joiner: Joiner::new(joiner),
         }
     }
 }

--- a/src/log/async_log.rs
+++ b/src/log/async_log.rs
@@ -282,7 +282,7 @@ pub fn make_json_pattern(unique_id: u64) -> PatternLayout {
                            \"module\":\"%M\",\"file\":\"%f\",\"line\":\"%L\",\"msg\":\"%m\"}}",
                           unique_id);
 
-    unwrap_result!(PatternLayout::new(&pattern))
+    unwrap!(PatternLayout::new(&pattern))
 }
 
 #[derive(Debug)]
@@ -316,7 +316,7 @@ impl AsyncAppender {
         let (tx, rx) = mpsc::channel::<AsyncEvent>();
 
         let joiner = thread!("AsyncLog", move || {
-            let re = unwrap_result!(Regex::new(r"#FS#?.*[/\\#]([^#]+)#FE#"));
+            let re = unwrap!(Regex::new(r"#FS#?.*[/\\#]([^#]+)#FE#"));
 
             for event in rx.iter() {
                 match event {

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -47,6 +47,7 @@
 //! #[macro_use]
 //! extern crate log;
 //! #[macro_use]
+//! extern crate unwrap;
 //! extern crate maidsafe_utilities;
 //! use std::thread;
 //! use maidsafe_utilities::thread::Joiner;
@@ -58,15 +59,15 @@
 //! }
 //!
 //! fn main() {
-//!     unwrap_result!(maidsafe_utilities::log::init(true));
+//!     unwrap!(maidsafe_utilities::log::init(true));
 //!
 //!     my_mod::show_warning();
 //!
 //!     let unnamed = thread::spawn(move || info!("Message in unnamed thread"));
 //!     let _ = unnamed.join();
 //!
-//!     let _named = Joiner::new(thread!("Worker",
-//!                                      move || error!("Message in named thread")));
+//!     let _named = maidsafe_utilities::thread::named("Worker",
+//!                                      move || error!("Message in named thread"));
 //!
 //!     // WARN 16:10:44.989712300 <main> [example::my_mod main.rs:10] A warning
 //!     // INFO 16:10:44.990716600 <unnamed> [example main.rs:19] Message in unnamed thread
@@ -115,7 +116,7 @@ pub fn init(show_thread_name: bool) -> Result<(), String> {
     let mut result = Err("Logger already initialised".to_owned());
 
     INITIALISE_LOGGER.call_once(|| {
-        let mut config_path = unwrap_result!(env::current_exe());
+        let mut config_path = unwrap!(env::current_exe());
         config_path.set_file_name(CONFIG_FILE);
 
         result = if config_path.is_file() {
@@ -364,7 +365,7 @@ fn make_pattern(show_thread_name: bool) -> PatternLayout {
         "%l %d{%H:%M:%S.%f} [%M #FS#%f#FE#:%L] %m"
     };
 
-    unwrap_result!(PatternLayout::new(pattern))
+    unwrap!(PatternLayout::new(pattern))
 }
 
 #[derive(Debug)]
@@ -515,9 +516,9 @@ mod test {
         let _raii_joiner = Joiner::new(thread!("LogMessageServer", move || {
             use std::io::Read;
 
-            let listener = unwrap_result!(TcpListener::bind("127.0.0.1:55555"));
-            unwrap_result!(tx.send(()));
-            let (mut stream, _) = unwrap_result!(listener.accept());
+            let listener = unwrap!(TcpListener::bind("127.0.0.1:55555"));
+            unwrap!(tx.send(()));
+            let (mut stream, _) = unwrap!(listener.accept());
 
             let mut log_msgs = Vec::with_capacity(MSG_COUNT);
 
@@ -526,7 +527,7 @@ mod test {
             let mut search_frm_index = 0;
 
             while log_msgs.len() < MSG_COUNT {
-                let bytes_rxd = unwrap_result!(stream.read(&mut scratch_buf));
+                let bytes_rxd = unwrap!(stream.read(&mut scratch_buf));
                 if bytes_rxd == 0 {
                     unreachable!("Should not have encountered shutdown yet");
                 }
@@ -535,7 +536,7 @@ mod test {
 
                 while read_buf.len() - search_frm_index >= MSG_TERMINATOR.len() {
                     if read_buf[search_frm_index..].starts_with(&MSG_TERMINATOR) {
-                        log_msgs.push(unwrap_result!(
+                        log_msgs.push(unwrap!(
                                 str::from_utf8(&read_buf[..search_frm_index]))
                             .to_owned());
                         read_buf = read_buf.split_off(search_frm_index + MSG_TERMINATOR.len());
@@ -552,9 +553,9 @@ mod test {
             }
         }));
 
-        unwrap_result!(rx.recv());
+        unwrap!(rx.recv());
 
-        unwrap_result!(init_to_server("127.0.0.1:55555", true, false));
+        unwrap!(init_to_server("127.0.0.1:55555", true, false));
 
         info!("This message should not be found by default log level");
         warn!("This is message 0");
@@ -589,18 +590,18 @@ mod test {
 
             impl Handler for Server {
                 fn on_message(&mut self, msg: Message) -> ws::Result<()> {
-                    let text = unwrap_result!(msg.as_text());
+                    let text = unwrap!(msg.as_text());
                     assert!(text.contains(&format!("This is message {}", self.count)[..]));
                     self.count += 1;
                     if self.count == MSG_COUNT {
-                        unwrap_result!(self.tx.send(()));
+                        unwrap!(self.tx.send(()));
                     }
 
                     Ok(())
                 }
             }
 
-            unwrap_result!(ws::listen("127.0.0.1:44444", |_| {
+            unwrap!(ws::listen("127.0.0.1:44444", |_| {
                 Server {
                     tx: tx.clone(),
                     count: 0,
@@ -611,7 +612,7 @@ mod test {
         // Allow sometime for server to start listening
         thread::sleep(Duration::from_millis(100));
 
-        unwrap_result!(init_to_web_socket("ws://127.0.0.1:44444", false, false));
+        unwrap!(init_to_web_socket("ws://127.0.0.1:44444", false, false));
 
         info!("This message should not be found by default log level");
         warn!("This is message 0");
@@ -626,6 +627,6 @@ mod test {
         debug!("This message should not be found by default log level");
         error!("This is message 2");
 
-        unwrap_result!(rx.recv());
+        unwrap!(rx.recv());
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -49,7 +49,7 @@
 //! #[macro_use]
 //! extern crate maidsafe_utilities;
 //! use std::thread;
-//! use maidsafe_utilities::thread::RaiiThreadJoiner;
+//! use maidsafe_utilities::thread::Joiner;
 //!
 //! mod my_mod {
 //!     pub fn show_warning() {
@@ -65,8 +65,8 @@
 //!     let unnamed = thread::spawn(move || info!("Message in unnamed thread"));
 //!     let _ = unnamed.join();
 //!
-//!     let _named = RaiiThreadJoiner::new(thread!("Worker",
-//!                                                move || error!("Message in named thread")));
+//!     let _named = Joiner::new(thread!("Worker",
+//!                                      move || error!("Message in named thread")));
 //!
 //!     // WARN 16:10:44.989712300 <main> [example::my_mod main.rs:10] A warning
 //!     // INFO 16:10:44.990716600 <unnamed> [example main.rs:19] Message in unnamed thread
@@ -445,7 +445,7 @@ mod test {
     use ws;
     use ws::{Message, Handler};
     use logger::LogLevelFilter;
-    use thread::RaiiThreadJoiner;
+    use thread::Joiner;
 
     #[test]
     fn test_parse_loggers() {
@@ -512,7 +512,7 @@ mod test {
         let (tx, rx) = mpsc::channel();
 
         // Start Log Message Server
-        let _raii_joiner = RaiiThreadJoiner::new(thread!("LogMessageServer", move || {
+        let _raii_joiner = Joiner::new(thread!("LogMessageServer", move || {
             use std::io::Read;
 
             let listener = unwrap_result!(TcpListener::bind("127.0.0.1:55555"));

--- a/src/log/web_socket.rs
+++ b/src/log/web_socket.rs
@@ -24,11 +24,11 @@ use std::io::{Error, ErrorKind, Result};
 use ws;
 use ws::{CloseCode, Handshake, Handler, Message};
 
-use thread::RaiiThreadJoiner;
+use thread::Joiner;
 
 pub struct WebSocket {
     ws_tx: ws::Sender,
-    _raii_joiner: RaiiThreadJoiner,
+    _raii_joiner: Joiner,
 }
 
 impl WebSocket {
@@ -75,7 +75,7 @@ impl WebSocket {
             Ok(Ok(ws_tx)) => {
                 Ok(WebSocket {
                     ws_tx: ws_tx,
-                    _raii_joiner: RaiiThreadJoiner::new(joiner),
+                    _raii_joiner: Joiner::new(joiner),
                 })
             }
             Ok(Err(e)) => Err(e),

--- a/src/log/web_socket.rs
+++ b/src/log/web_socket.rs
@@ -61,7 +61,7 @@ impl WebSocket {
             match ws::connect(url, |ws_tx| {
                 Client {
                     ws_tx: ws_tx,
-                    tx: unwrap_option!(tx_opt.take(), "Logic Error! Report as bug."),
+                    tx: unwrap!(tx_opt.take(), "Logic Error! Report as bug."),
                 }
             }) {
                 Ok(()) => (),

--- a/src/serialisation.rs
+++ b/src/serialisation.rs
@@ -116,9 +116,9 @@ mod test {
     fn serialise_deserialise() {
         let original_data = (vec![0u8, 1, 3, 9], vec![-1i64, 888, -8765], "Some-String".to_owned());
 
-        let serialised_data = unwrap_result!(serialise(&original_data));
+        let serialised_data = unwrap!(serialise(&original_data));
         let deserialised_data: (Vec<u8>, Vec<i64>, String) =
-            unwrap_result!(deserialise(&serialised_data));
+            unwrap!(deserialise(&serialised_data));
         assert_eq!(original_data, deserialised_data);
     }
 
@@ -126,11 +126,11 @@ mod test {
     fn serialise_into_deserialise_from() {
         let original_data = (vec![0u8, 1, 3, 9], vec![-1i64, 888, -8765], "Some-String".to_owned());
         let mut serialised_data = vec![];
-        unwrap_result!(serialise_into(&original_data, &mut serialised_data));
+        unwrap!(serialise_into(&original_data, &mut serialised_data));
 
         let mut serialised = Cursor::new(serialised_data);
         let deserialised_data: (Vec<u8>, Vec<i64>, String) =
-            unwrap_result!(deserialise_from(&mut serialised));
+            unwrap!(deserialise_from(&mut serialised));
         assert_eq!(original_data, deserialised_data);
     }
 
@@ -142,14 +142,14 @@ mod test {
         };
         // Test with data which is at limit
         let mut original_data = (1u64..(upper_limit / 8)).collect::<Vec<_>>();
-        let mut serialised_data = unwrap_result!(serialise(&original_data));
-        let mut deserialised_data: Vec<u64> = unwrap_result!(deserialise(&serialised_data));
+        let mut serialised_data = unwrap!(serialise(&original_data));
+        let mut deserialised_data: Vec<u64> = unwrap!(deserialise(&serialised_data));
         assert!(original_data == deserialised_data);
 
         serialised_data.clear();
-        unwrap_result!(serialise_into(&original_data, &mut serialised_data));
+        unwrap!(serialise_into(&original_data, &mut serialised_data));
         let mut serialised = Cursor::new(serialised_data);
-        deserialised_data = unwrap_result!(deserialise_from(&mut serialised));
+        deserialised_data = unwrap!(deserialise_from(&mut serialised));
         assert_eq!(original_data, deserialised_data);
 
         // Try to serialise data above limit
@@ -165,7 +165,7 @@ mod test {
         }
 
         // Try to deserialise data above limit
-        let excessive = unwrap_result!(encode(&original_data, SizeLimit::Infinite));
+        let excessive = unwrap!(encode(&original_data, SizeLimit::Infinite));
         if let Err(SerialisationError::Deserialise(DecodingError::SizeLimit)) =
                deserialise::<Vec<u64>>(&excessive) {} else {
             panic!("Expected size limit error.");
@@ -177,20 +177,20 @@ mod test {
         }
 
         // Try to serialise data above default limit with size limit specified
-        serialised_data = unwrap_result!(serialise_with_limit(&original_data, SizeLimit::Infinite));
+        serialised_data = unwrap!(serialise_with_limit(&original_data, SizeLimit::Infinite));
 
         buffer = Vec::with_capacity(serialised_data.len());
-        unwrap_result!(serialise_into_with_limit(&original_data, &mut buffer, SizeLimit::Infinite));
+        unwrap!(serialise_into_with_limit(&original_data, &mut buffer, SizeLimit::Infinite));
 
         assert_eq!(serialised_data, buffer);
 
         // Try to deserialise data above default limit with size limit specified
-        let deserialised_data_0: Vec<u64> = unwrap_result!(deserialise_with_limit(&serialised_data,
+        let deserialised_data_0: Vec<u64> = unwrap!(deserialise_with_limit(&serialised_data,
                                                                         SizeLimit::Infinite));
         assert_eq!(original_data, deserialised_data_0);
         let deserialised_data_1: Vec<u64> =
-            unwrap_result!(deserialise_from_with_limit(&mut Cursor::new(buffer),
-                                                       SizeLimit::Infinite));
+            unwrap!(deserialise_from_with_limit(&mut Cursor::new(buffer),
+                                                SizeLimit::Infinite));
         assert_eq!(original_data, deserialised_data_1);
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -73,24 +73,24 @@ macro_rules! thread {
 /// #Examples
 ///
 /// ```
-/// let _ = maidsafe_utilities::thread::spawn("DaemonThread", move || {
+/// let _ = maidsafe_utilities::thread::named("DaemonThread", move || {
 ///     std::thread::sleep(std::time::Duration::from_millis(10));
 /// });
 ///
 /// let sleep_duration_ms = 500;
 /// let _raii_joiner = maidsafe_utilities::thread
-///                                      ::RaiiThreadJoiner::new(maidsafe_utilities::thread::spawn("ManagedThread", move || {
+///                                      ::RaiiThreadJoiner::new(maidsafe_utilities::thread::named("ManagedThread", move || {
 ///     std::thread::sleep(std::time::Duration::from_millis(sleep_duration_ms));
 /// }));
 /// ```
-pub fn spawn<S, F>(thread_name: S, func: F) -> JoinHandle<()>
+pub fn named<S, F>(thread_name: S, func: F) -> JoinHandle<()>
     where S: Into<String>,
           F: FnOnce() + Send + 'static
 {
     let thread_name: String = thread_name.into();
-    let t = std::thread::Builder::new().name(thread_name)
-                                       .spawn(func);
-    unwrap_result!(t)
+    let join_handle_res = std::thread::Builder::new().name(thread_name)
+                                               .spawn(func);
+    unwrap_result!(join_handle_res)
 }
 
 #[cfg(test)]

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -35,15 +35,15 @@ impl Joiner {
 
     /// Releases the `Joiner` by detaching the thread.
     pub fn detach(mut self) {
-        let _ = unwrap_option!(self.joiner.take(),
-                               "Programming error: please report this as a bug.");
+        let _ = unwrap!(self.joiner.take(),
+                        "Programming error: please report this as a bug.");
     }
 }
 
 impl Drop for Joiner {
     fn drop(&mut self) {
         if let Some(joiner) = self.joiner.take() {
-            unwrap_result!(joiner.join());
+            unwrap!(joiner.join());
         }
     }
 }
@@ -56,6 +56,8 @@ impl Drop for Joiner {
 /// ```
 /// # #[macro_use]
 /// # extern crate maidsafe_utilities;
+/// # #[macro_use]
+/// # extern crate unwrap;
 /// # fn main() {
 /// let _ = thread!("DaemonThread", move || {
 ///     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -71,8 +73,8 @@ impl Drop for Joiner {
 #[macro_export]
 macro_rules! thread {
     ($thread_name:expr, $entry_point:expr) => {
-        unwrap_result!(::std::thread::Builder::new().name($thread_name.to_owned())
-                                                    .spawn($entry_point))
+        unwrap!(::std::thread::Builder::new().name($thread_name.to_owned())
+                                             .spawn($entry_point))
     }
 }
 
@@ -98,7 +100,7 @@ pub fn named<S, F>(thread_name: S, func: F) -> Joiner
     let thread_name: String = thread_name.into();
     let join_handle_res = std::thread::Builder::new().name(thread_name)
                                                .spawn(func);
-    Joiner::new(unwrap_result!(join_handle_res))
+    Joiner::new(unwrap!(join_handle_res))
 }
 
 #[cfg(test)]
@@ -116,9 +118,9 @@ mod test {
         {
             let time_before = Instant::now();
             {
-                let _ = thread!("JoinerTestDaemon", move || {
+                named("JoinerTestDaemon", move || {
                     thread::sleep(Duration::from_millis(SLEEP_DURATION_DAEMON));
-                });
+                }).detach();
             }
             let diff = time_before.elapsed();
 
@@ -128,9 +130,9 @@ mod test {
         {
             let time_before = Instant::now();
             {
-                let _raii_joiner = Joiner::new(thread!("JoinerTestManaged", move || {
+                let _joiner = named("JoinerTestManaged", move || {
                     thread::sleep(Duration::from_millis(SLEEP_DURATION_MANAGED));
-                }));
+                });
             }
             let diff = time_before.elapsed();
 

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use maidsafe_utilities::log as safe_log;
 
 fn main() {
-    unwrap_result!(safe_log::init(false));
+    unwrap!(safe_log::init(false));
 
     trace!("This is a log message.");
     debug!("This is a log message.");


### PR DESCRIPTION
This provides alternative to the now deprecated `thread!` macro into a function so that the `line!` and `column!` macro will work correctly inside of it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/65)

<!-- Reviewable:end -->
