### PR TITLE
feat/seeded RNG: change from error to panic

### DIFF
--- a/src/seeded_rng.rs
+++ b/src/seeded_rng.rs
@@ -15,41 +15,19 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 use rand::{self, Rng, SeedableRng, XorShiftRng};
 
 lazy_static! {
-    static ref IS_INITIALISED: AtomicBool = AtomicBool::new(false);
-    static ref SEED: Mutex<[u32; 4]> =
-        Mutex::new([rand::random(), rand::random(), rand::random(), rand::random()]);
-}
-
-/// Error indicating that the static seed has already been initialised to a different value.
-#[derive(Debug)]
-pub struct AlreadySeeded;
-
-impl Display for AlreadySeeded {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter,
-               "The static seed has already been initialised to a different value via a call to \
-                `SeededRng::new()` or `SeededRng::from_seed()`.")
-    }
-}
-
-impl Error for AlreadySeeded {
-    fn description(&self) -> &str {
-        "already seeded"
-    }
+    static ref SEED: Mutex<Option<[u32; 4]>> = Mutex::new(None);
 }
 
 /// A [fast pseudorandom number generator]
-/// (https://doc.rust-lang.org/rand/rand/struct.XorShiftRng.html) that allows seeding and prints the
-/// seed when the thread in which it is created panics.
+/// (https://doc.rust-lang.org/rand/rand/struct.XorShiftRng.html) for use in tests which allows
+/// seeding and prints the seed when the thread in which it is created panics.
 pub struct SeededRng {
     seed: [u32; 4],
     inner: XorShiftRng,
@@ -57,11 +35,19 @@ pub struct SeededRng {
 
 impl SeededRng {
     /// Construct a new `SeededRng` using a seed generated from cryptographically secure random
-    /// data.  The seed is only set once for the whole process, so every call to this will yield
-    /// internal RNGs which are all seeded identically.
+    /// data.
+    ///
+    /// The seed is only set once for the whole process, so every call to this will yield internal
+    /// RNGs which are all seeded identically.
     pub fn new() -> Self {
-        let seed: [u32; 4] = *unwrap!(SEED.lock());
-        IS_INITIALISED.store(true, Ordering::Relaxed);
+        let mut optional_seed = &mut *unwrap!(SEED.lock());
+        let seed = if let Some(current_seed) = *optional_seed {
+            current_seed
+        } else {
+            let new_seed = [rand::random(), rand::random(), rand::random(), rand::random()];
+            *optional_seed = Some(new_seed);
+            new_seed
+        };
         SeededRng {
             seed: seed,
             inner: XorShiftRng::from_seed(seed),
@@ -69,21 +55,27 @@ impl SeededRng {
     }
 
     /// Construct a new `SeededRng` using `seed`.
-    pub fn from_seed(seed: [u32; 4]) -> Result<Self, AlreadySeeded> {
-        let mut current_seed = &mut *unwrap!(SEED.lock());
-        if IS_INITIALISED.load(Ordering::Relaxed) {
-            if *current_seed != seed {
-                return Err(AlreadySeeded);
+    ///
+    /// If the underlying static seed has already been initialised to a value different to `seed`,
+    /// then this function will panic.
+    pub fn from_seed(seed: [u32; 4]) -> Self {
+        let mut optional_seed = &mut *unwrap!(SEED.lock());
+        if let Some(current_seed) = *optional_seed {
+            if current_seed != seed {
+                panic!("\nThe static seed has already been initialised to a different value via \
+                        a call to `SeededRng::new()`\nor `SeededRng::from_seed(...)`.  This \
+                        could be due to setting a hard-coded value for the seed in a\nsingle \
+                        test case, but running the whole test suite.  If so, try running just \
+                        the single test case.\n");
             }
         } else {
-            *current_seed = seed;
-            IS_INITIALISED.store(true, Ordering::Relaxed);
+            *optional_seed = Some(seed);
         }
 
-        Ok(SeededRng {
-            seed: *current_seed,
-            inner: XorShiftRng::from_seed(*current_seed),
-        })
+        SeededRng {
+            seed: seed,
+            inner: XorShiftRng::from_seed(seed),
+        }
     }
 
     /// Construct a new [`XorShiftRng`](https://doc.rust-lang.org/rand/rand/struct.XorShiftRng.html)
@@ -137,27 +129,38 @@ mod tests {
     use super::*;
     use rand::Rng;
 
+    // We need the expected message here to ensure that any assertion failure in the test causes the
+    // test to fail.  Only the final statement should cause a panic (calling `from_seed()` with a
+    // different seed value).  This check can't be moved to its own test case since if it runs
+    // first it will poison the mutex protecting the static seed, causing this test to fail.
     #[test]
+    #[should_panic(expected = "\nThe static seed has already been initialised to a different value \
+                               via a call to `SeededRng::new()`\nor `SeededRng::from_seed(...)`.  \
+                               This could be due to setting a hard-coded value for the seed in \
+                               a\nsingle test case, but running the whole test suite.  If so, try \
+                               running just the single test case.\n")]
     fn seeded_rng() {
-        let seed = [0, 1, 2, 3];
-        let mut seeded_rng1 = unwrap!(SeededRng::from_seed(seed));
-        let mut seeded_rng2 = SeededRng::new();
-        let expected = 12884903946;
-        assert_eq!(seeded_rng1.next_u64(), expected);
-        assert_eq!(seeded_rng2.next_u64(), expected);
+        {
+            let seed = [0, 1, 2, 3];
+            let mut seeded_rng1 = SeededRng::from_seed(seed);
+            let mut seeded_rng2 = SeededRng::new();
+            let expected = 12884903946;
+            assert_eq!(seeded_rng1.next_u64(), expected);
+            assert_eq!(seeded_rng2.next_u64(), expected);
 
-        let mut rng1_from_seeded_rng1 = seeded_rng1.new_rng();
-        let mut rng2_from_seeded_rng1 = seeded_rng1.new_rng();
-        let expected1 = 36055743652167817;
-        let expected2 = 19781043125127688;
-        assert_eq!(rng1_from_seeded_rng1.next_u64(), expected1);
-        assert_eq!(rng2_from_seeded_rng1.next_u64(), expected2);
+            let mut rng1_from_seeded_rng1 = seeded_rng1.new_rng();
+            let mut rng2_from_seeded_rng1 = seeded_rng1.new_rng();
+            let expected1 = 36055743652167817;
+            let expected2 = 19781043125127688;
+            assert_eq!(rng1_from_seeded_rng1.next_u64(), expected1);
+            assert_eq!(rng2_from_seeded_rng1.next_u64(), expected2);
 
-        let mut rng1_from_seeded_rng2 = seeded_rng2.new_rng();
-        let mut rng2_from_seeded_rng2 = seeded_rng2.new_rng();
-        assert_eq!(rng1_from_seeded_rng2.next_u64(), expected1);
-        assert_eq!(rng2_from_seeded_rng2.next_u64(), expected2);
+            let mut rng1_from_seeded_rng2 = seeded_rng2.new_rng();
+            let mut rng2_from_seeded_rng2 = seeded_rng2.new_rng();
+            assert_eq!(rng1_from_seeded_rng2.next_u64(), expected1);
+            assert_eq!(rng2_from_seeded_rng2.next_u64(), expected2);
+        }
 
-        assert!(SeededRng::from_seed([3, 2, 1, 0]).is_err());
+        let _ = SeededRng::from_seed([3, 2, 1, 0]);
     }
 }


### PR DESCRIPTION
This changes `SeededRng::from_seed()` to panic rather than return an error if the seed is different
to the existing value for the the static seed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/70)

<!-- Reviewable:end -->
