### PR TITLE
Added {n} formatter at end of patterns in order to generate a newline…

### DIFF
--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -367,9 +367,9 @@ pub fn init_to_web_socket<U: Borrow<str>>(server_url: U,
 
 fn make_pattern(show_thread_name: bool) -> PatternEncoder {
     let pattern = if show_thread_name {
-        "{l} {d(%H:%M:%S.%f)} {T} [{M} #FS#{f}#FE#:{L}] {m}"
+        "{l} {d(%H:%M:%S.%f)} {T} [{M} #FS#{f}#FE#:{L}] {m}{n}"
     } else {
-        "{l} {d(%H:%M:%S.%f)} [{M} #FS#{f}#FE#:{L}] {m}"
+        "{l} {d(%H:%M:%S.%f)} [{M} #FS#{f}#FE#:{L}] {m}{n}"
     };
 
     PatternEncoder::new(pattern)

--- a/test/log.toml
+++ b/test/log.toml
@@ -11,7 +11,7 @@ kind = "console"
 [appenders.async_file]
 kind = "async_file"
 output_file_name = "This-is-a-sample-output.log"
-pattern = "{l} {d(%H:%M:%S.%f)} [{M} #FS#{f}#FE#:{L}] {m}\n"
+pattern = "{l} {d(%H:%M:%S.%f)} [{M} #FS#{f}#FE#:{L}] {m}{n}"
 append = true
 
 # This will log all levels from log_test into file and web socket.


### PR DESCRIPTION
… after each message (to correct regression since upgrade to log4rs 0.4)

The messages displayed at the console weren't terminated with a newline, generating this kind of unreadable log:

NFO 19:42:35.251977800 [multi_vaults multi_vaults.rs:568] Starting 12 vaults.INFO 19:42:36.270181700 [multi_vaults multi_vaults.rs:600] Starting vault 00INFO 19:42:37.789675100 [multi_vaults multi_vaults.rs:600] Starting vault 01INFO 19:42:39.994936800 [multi_vaults multi_vaults.rs:600] Starting vault 02INFO 19:42:42.886802600 [multi_vaults multi_vaults.rs:600] Starting vault 03WARN 19:42:44.089914500 [crust::main::service service.rs:249] Already connected OR already in process of connecting to PeerId(c720..)WARN 19:42:44.105540400 [crust::main::service service.rs:249] Already connected OR already in process of connecting to PeerId(c720..)INFO 19:42:46.511751700 [multi_vaults multi_vaults.rs:600] Starting vault 04

This is corrected by adding the {n} pattern which generates:

INFO 20:06:46.822474600 [multi_vaults multi_vaults.rs:568] Starting 12 vaults.
INFO 20:06:47.840684000 [multi_vaults multi_vaults.rs:600] Starting vault 00
INFO 20:06:49.360091800 [multi_vaults multi_vaults.rs:600] Starting vault 01
INFO 20:06:51.565797800 [multi_vaults multi_vaults.rs:600] Starting vault 02
INFO 20:06:54.457542600 [multi_vaults multi_vaults.rs:600] Starting vault 03
WARN 20:06:55.660654800 [crust::main::service service.rs:249] Already connected OR already in process of connecting to PeerId(9a4a..)
WARN 20:06:55.676280400 [crust::main::service service.rs:249] Already connected OR already in process of connecting to PeerId(b6a7..)
INFO 20:06:58.082490800 [multi_vaults multi_vaults.rs:600] Starting vault 04

which is much better and which was generated before the regression.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_utilities/76)

<!-- Reviewable:end -->
