### PR TITLE
update forum links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 |:---:|:--------:|:---------:|:-----:|:------:|:----:|
 |[![](http://meritbadge.herokuapp.com/maidsafe_utilities)](https://crates.io/crates/maidsafe_utilities)|[![Build Status](https://travis-ci.org/maidsafe/maidsafe_utilities.svg?branch=master)](https://travis-ci.org/maidsafe/maidsafe_utilities)|[![Build Status](http://ci.maidsafe.net:8080/buildStatus/icon?job=maidsafe_utilities_arm_status_badge)](http://ci.maidsafe.net:8080/job/maidsafe_utilities_arm_status_badge/)|[![Build status](https://ci.appveyor.com/api/projects/status/f7x8p4y66lwua38t/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/maidsafe-utilities/branch/master)|[![Coverage Status](https://coveralls.io/repos/maidsafe/maidsafe_utilities/badge.svg)](https://coveralls.io/r/maidsafe/maidsafe_utilities)|[![Stories in Ready](https://badge.waffle.io/maidsafe/maidsafe_utilities.png?label=ready&title=Ready)](https://waffle.io/maidsafe/maidsafe_utilities)|
 
-
-| [API Documentation - master branch](http://docs.maidsafe.net/maidsafe_utilities/master) | [MaidSafe website](http://maidsafe.net) | [SAFE Network Forum](https://forum.safenetwork.io) |
+| [API Docs - master branch](http://docs.maidsafe.net/maidsafe_utilities/master) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:------:|:-------:|:-------:|:-------:|
 
 ## Overview


### PR DESCRIPTION
As explained in [this topic](https://safenetforum.org/t/please-update-your-forum-bookmark-to-safenetforum-org/11358), the previous URL is no longer working. The new URL of the SAFE Network Forum is [safenetforum.org](https://safenetforum.org/).

I also added a link to the new [Dev Forum](https://forum.safedev.org/).