### PR TITLE
MAID-2000: chore/all: cleanup/improve CI scripts and README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-    - secure: NVv3DlmpA4AdSd8377CTW/4uNBNTs6M//wD6lU6fnmwLaifbkGfKM7wt77LE/mAFG+RfmOBVgu8wcHQf3i3D3sevbXNLHCeZJO0rW5bO4tAXMrAviVjtS9lsv02ilYYfBtyH29f+YEJcpYs5EdsNzcHSGsj7e+XBgsG7ehAnRYCza+xdw5vbKuz/dH7qR3/yoxlRwQ4/V0oK/DkCicz2dFmcrXDOwZ3qUxIS6PluHY1JXrFsBD1AgGZbg1C3P0tnPMLed5cj9wa9aEu3OkGMlgdZD+JxqOh3Uu9RQQGCDTsJmsJ+mt8OPxrgCSfjhBF2CqEGVrkAfr9Rf0qvPza7AoxptkENgCdo8z4fuKakCO/K1PkKzTnUs7OGIYRNf7PHXUBHLQjo4lP1dWpmsmSL1YfxErT+N8knk377r5QWo8iKfXJa4ubtErS3kkQ/Al3Zw5Cm1IcDmYMU/Wx2FPEhynGwrJkNRpoP1Ma8btOk1mToYzC0MRlhui16GYgM9Oiyy5UmZcZrNZmn7xkmJn9xkz4XlnsYoYCvuk8KJX8YvbAS/s3NQBjQYFhDNGJeflm5k8DDkL6NCrpv0ICfKF+jk44TVpRfTQlBhbndeGv21teTRbT0hNZUjLvquez1t9p49xuxmEcA+7R4gs/SNd22Lr0dRcfOYnXm0jqWESKng5k=
 os:
   - linux
   - osx
@@ -10,9 +9,6 @@ language: rust
 rust:
   - stable
   - nightly-2016-12-19
-matrix:
-  allow_failures:
-    - rust: nightly
 sudo: false
 branches:
   only:
@@ -32,16 +28,16 @@ before_script:
     fi
 script:
   - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
-        (
-            set -x;
-            cargo fmt -- --write-mode=diff &&
-            cargo test --verbose --release
-        );
+      (
+        set -x;
+        cargo fmt -- --write-mode=diff &&
+        cargo test --release --verbose
+      );
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-        (
-            set -x;
-            cargo clippy && cargo clippy --profile=test
-        )
+      (
+        set -x;
+        cargo clippy && cargo clippy --profile=test
+      );
     fi
 before_cache:
   - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Rust utility functions provided by MaidSafe."
-documentation = "http://docs.maidsafe.net/maidsafe_utilities/latest"
-homepage = "http://maidsafe.net"
+documentation = "https://docs.rs/maidsafe_utilities"
+homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "maidsafe_utilities"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 **Maintainer:** Spandan Sharma (spandan.sharma@maidsafe.net)
 
-|Crate|Documentation|Linux/OS X|ARM (Linux)|Windows|Issues|
-|:---:|:-----------:|:--------:|:---------:|:-----:|:----:|
-|[![](http://meritbadge.herokuapp.com/maidsafe_utilities)](https://crates.io/crates/maidsafe_utilities)|[![Documentation](https://docs.rs/maidsafe_utilities/badge.svg)](https://docs.rs/maidsafe_utilities)|[![Build Status](https://travis-ci.org/maidsafe/maidsafe_utilities.svg?branch=master)](https://travis-ci.org/maidsafe/maidsafe_utilities)|[![Build Status](http://ci.maidsafe.net:8080/buildStatus/icon?job=maidsafe_utilities_arm_status_badge)](http://ci.maidsafe.net:8080/job/maidsafe_utilities_arm_status_badge/)|[![Build status](https://ci.appveyor.com/api/projects/status/f7x8p4y66lwua38t/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/maidsafe-utilities/branch/master)|[![Stories in Ready](https://badge.waffle.io/maidsafe/maidsafe_utilities.png?label=ready&title=Ready)](https://waffle.io/maidsafe/maidsafe_utilities)|
+|Crate|Documentation|Linux/OS X|Windows|Issues|
+|:---:|:-----------:|:--------:|:-----:|:----:|
+|[![](http://meritbadge.herokuapp.com/maidsafe_utilities)](https://crates.io/crates/maidsafe_utilities)|[![Documentation](https://docs.rs/maidsafe_utilities/badge.svg)](https://docs.rs/maidsafe_utilities)|[![Build Status](https://travis-ci.org/maidsafe/maidsafe_utilities.svg?branch=master)](https://travis-ci.org/maidsafe/maidsafe_utilities)|[![Build status](https://ci.appveyor.com/api/projects/status/f7x8p4y66lwua38t/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/maidsafe-utilities/branch/master)|[![Stories in Ready](https://badge.waffle.io/maidsafe/maidsafe_utilities.png?label=ready&title=Ready)](https://waffle.io/maidsafe/maidsafe_utilities)|
 
-
-| [MaidSafe website](http://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
-|:-------:|:-------:|:-------:|
+| [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+|:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
 
 ## Overview
 
@@ -26,6 +25,5 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
-work by you, as defined in the MaidSafe Contributor Agreement, version 1.1 ([CONTRIBUTOR]
-(CONTRIBUTOR)), shall be dual licensed as above, and you agree to be bound by the terms of the
-MaidSafe Contributor Agreement, version 1.1.
+work by you, as defined in the MaidSafe Contributor Agreement ([CONTRIBUTOR](CONTRIBUTOR)), shall be
+dual licensed as above, and you agree to be bound by the terms of the MaidSafe Contributor Agreement.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,16 @@ environment:
     RUST_BACKTRACE: 1
   matrix:
     - RUST_VERSION: stable
+
 branches:
   only:
     - master
 
-clone_depth: 50
+cache:
+  - '%USERPROFILE%\.cargo'
+  - '%APPVEYOR_BUILD_FOLDER%\target'
+
+clone_depth: 1
 
 install:
   - ps: |
@@ -20,7 +25,6 @@ platform:
   - x64
 
 configuration:
-#  - Debug
   - Release
 
 build_script:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 reorder_imports = true
 reorder_imported_names = true
+use_try_shorthand = true

--- a/src/big_endian_sip_hash.rs
+++ b/src/big_endian_sip_hash.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -14,7 +14,6 @@
 //
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
-
 
 use bincode::{self, SizeLimit};
 use rustc_serialize::Encodable;

--- a/src/event_sender.rs
+++ b/src/event_sender.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,8 +21,8 @@
 
 #![doc(html_logo_url =
            "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
-       html_favicon_url = "http://maidsafe.net/img/favicon.ico",
-       html_root_url = "http://maidsafe.github.io/maidsafe_utilities")]
+       html_favicon_url = "https://maidsafe.net/img/favicon.ico",
+       html_root_url = "https://docs.rs/maidsafe_utilities")]
 
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
@@ -37,12 +37,6 @@
         unused_qualifications, unused_results)]
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
          missing_debug_implementations, variant_size_differences)]
-
-#![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
-#![cfg_attr(feature="clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
-                                   option_unwrap_used))]
-#![cfg_attr(feature="clippy", allow(use_debug, doc_markdown, useless_let_if_seq))]
 
 extern crate bincode;
 extern crate config_file_handler;

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -136,18 +136,18 @@ pub fn init(show_thread_name: bool) -> Result<(), String> {
             let console_appender = AsyncConsoleAppender::builder()
                 .encoder(Box::new(make_pattern(show_thread_name)))
                 .build();
-            let console_appender = Appender::builder()
-                .build("async_console".to_owned(), Box::new(console_appender));
+            let console_appender =
+                Appender::builder().build("async_console".to_owned(), Box::new(console_appender));
 
             let (default_level, loggers) = unwrap!(parse_loggers_from_env(),
                                                    "failed to parse RUST_LOG env variable");
 
             let root = Root::builder().appender("async_console".to_owned()).build(default_level);
             let config = match Config::builder()
-                .appender(console_appender)
-                .loggers(loggers)
-                .build(root)
-                .map_err(|e| format!("{}", e)) {
+                      .appender(console_appender)
+                      .loggers(loggers)
+                      .build(root)
+                      .map_err(|e| format!("{}", e)) {
                 Ok(config) => config,
                 Err(e) => {
                     result = Err(e);
@@ -209,8 +209,8 @@ pub fn init_to_file<P: AsRef<Path>>(show_thread_name: bool,
             let console_appender = AsyncConsoleAppender::builder()
                 .encoder(Box::new(make_pattern(show_thread_name)))
                 .build();
-            let console_appender = Appender::builder()
-                .build("console".to_owned(), Box::new(console_appender));
+            let console_appender =
+                Appender::builder().build("console".to_owned(), Box::new(console_appender));
 
             config = config.appender(console_appender);
         }
@@ -258,9 +258,9 @@ pub fn init_to_server<A: ToSocketAddrs>(server_addr: A,
         let mut config = Config::builder().loggers(loggers);
 
         let server_appender = match AsyncServerAppender::builder(server_addr)
-            .encoder(Box::new(make_pattern(show_thread_name)))
-            .build()
-            .map_err(|e| format!("{}", e)) {
+                  .encoder(Box::new(make_pattern(show_thread_name)))
+                  .build()
+                  .map_err(|e| format!("{}", e)) {
             Ok(appender) => appender,
             Err(e) => {
                 result = Err(e);
@@ -268,8 +268,8 @@ pub fn init_to_server<A: ToSocketAddrs>(server_addr: A,
             }
         };
 
-        let server_appender = Appender::builder()
-            .build("server".to_owned(), Box::new(server_appender));
+        let server_appender =
+            Appender::builder().build("server".to_owned(), Box::new(server_appender));
 
         config = config.appender(server_appender);
 
@@ -277,8 +277,8 @@ pub fn init_to_server<A: ToSocketAddrs>(server_addr: A,
             let console_appender = AsyncConsoleAppender::builder()
                 .encoder(Box::new(make_pattern(show_thread_name)))
                 .build();
-            let console_appender = Appender::builder()
-                .build("console".to_owned(), Box::new(console_appender));
+            let console_appender =
+                Appender::builder().build("console".to_owned(), Box::new(console_appender));
 
             config = config.appender(console_appender);
         }
@@ -327,18 +327,19 @@ pub fn init_to_web_socket<U: Borrow<str>>(server_url: U,
 
         let mut config = Config::builder().loggers(loggers);
 
-        let server_appender = match AsyncWebSockAppender::builder(server_url)
-            .encoder(Box::new(async_log::make_json_pattern(rand::random())))
-            .build()
-            .map_err(|e| format!("{}", e)) {
-            Ok(appender) => appender,
-            Err(e) => {
-                result = Err(e);
-                return;
-            }
-        };
-        let server_appender = Appender::builder()
-            .build("server".to_owned(), Box::new(server_appender));
+        let server_appender =
+            match AsyncWebSockAppender::builder(server_url)
+                      .encoder(Box::new(async_log::make_json_pattern(rand::random())))
+                      .build()
+                      .map_err(|e| format!("{}", e)) {
+                Ok(appender) => appender,
+                Err(e) => {
+                    result = Err(e);
+                    return;
+                }
+            };
+        let server_appender =
+            Appender::builder().build("server".to_owned(), Box::new(server_appender));
 
         config = config.appender(server_appender);
 
@@ -346,8 +347,8 @@ pub fn init_to_web_socket<U: Borrow<str>>(server_url: U,
             let console_appender = AsyncConsoleAppender::builder()
                 .encoder(Box::new(make_pattern(show_thread_name_in_console)))
                 .build();
-            let console_appender = Appender::builder()
-                .build("console".to_owned(), Box::new(console_appender));
+            let console_appender =
+                Appender::builder().build("console".to_owned(), Box::new(console_appender));
 
             config = config.appender(console_appender);
         }
@@ -405,13 +406,11 @@ fn parse_loggers(input: &str) -> Result<(LogLevelFilter, Vec<Logger>), ParseLogg
     let mut grouped_modules = VecDeque::new();
     let mut default_level = DEFAULT_LOG_LEVEL_FILTER;
 
-    for sub_input in input.split(',')
-        .map(str::trim)
-        .filter(|d| !d.is_empty()) {
+    for sub_input in input.split(',').map(str::trim).filter(|d| !d.is_empty()) {
         let mut parts = sub_input.trim().split('=');
         match (parts.next(), parts.next()) {
             (Some(module_name), Some(level)) => {
-                let level_filter = try!(level.parse());
+                let level_filter = level.parse()?;
                 while let Some(module) = grouped_modules.pop_front() {
                     loggers.push(Logger::builder().build(module, level_filter));
                 }
@@ -540,7 +539,7 @@ mod tests {
                 while read_buf.len() - search_frm_index >= MSG_TERMINATOR.len() {
                     if read_buf[search_frm_index..].starts_with(&MSG_TERMINATOR) {
                         log_msgs.push(unwrap!(str::from_utf8(&read_buf[..search_frm_index]))
-                            .to_owned());
+                                          .to_owned());
                         read_buf = read_buf.split_off(search_frm_index + MSG_TERMINATOR.len());
                         search_frm_index = 0;
                     } else {

--- a/src/log/web_socket.rs
+++ b/src/log/web_socket.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,9 +44,9 @@ impl WebSocket {
                 fn on_open(&mut self, _: Handshake) -> ws::Result<()> {
                     if self.tx.send(Ok(self.ws_tx.clone())).is_err() {
                         Err(ws::Error {
-                            kind: ws::ErrorKind::Internal,
-                            details: From::from("Channel error - Could not send ws_tx."),
-                        })
+                                kind: ws::ErrorKind::Internal,
+                                details: From::from("Channel error - Could not send ws_tx."),
+                            })
                     } else {
                         Ok(())
                     }
@@ -71,9 +71,9 @@ impl WebSocket {
         match rx.recv() {
             Ok(Ok(ws_tx)) => {
                 Ok(WebSocket {
-                    ws_tx: ws_tx,
-                    _raii_joiner: joiner,
-                })
+                       ws_tx: ws_tx,
+                       _raii_joiner: joiner,
+                   })
             }
             Ok(Err(e)) => Err(e),
             Err(e) => Err(Error::new(ErrorKind::Other, format!("WebSocket Logger Error: {:?}", e))),
@@ -81,9 +81,10 @@ impl WebSocket {
     }
 
     pub fn write_all(&self, buf: &[u8]) -> Result<()> {
-        self.ws_tx
-            .send(Message::Binary(buf.to_owned()))
-            .map_err(|e| Error::new(ErrorKind::Other, format!("{:?}", e)))
+        self.ws_tx.send(Message::Binary(buf.to_owned())).map_err(|e| {
+                                                                     Error::new(ErrorKind::Other,
+                                                                                format!("{:?}", e))
+                                                                 })
     }
 }
 

--- a/src/seeded_rng.rs
+++ b/src/seeded_rng.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -14,7 +14,6 @@
 //
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
-
 
 use rand::{self, Rng, SeedableRng, XorShiftRng};
 use std::fmt::{self, Debug, Display, Formatter};

--- a/src/serialisation.rs
+++ b/src/serialisation.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -75,9 +75,7 @@ pub fn named<S, F>(thread_name: S, func: F) -> Joiner
           F: FnOnce() + Send + 'static
 {
     let thread_name: String = thread_name.into();
-    let join_handle_res = std::thread::Builder::new()
-        .name(thread_name)
-        .spawn(func);
+    let join_handle_res = std::thread::Builder::new().name(thread_name).spawn(func);
     Joiner::new(unwrap!(join_handle_res))
 }
 
@@ -98,7 +96,7 @@ mod tests {
             {
                 named("JoinerTestDaemon",
                       move || { thread::sleep(Duration::from_millis(SLEEP_DURATION_DAEMON)); })
-                    .detach();
+                        .detach();
             }
             let diff = time_before.elapsed();
 

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
* fixed some outdated URLs
* removed mention of a version of the Contributor Agreement
* improved AppVeyor and Travis scripts
* added standard rustfmt.toml and applied rustfmt
* fixed clippy warnings