### PR TITLE
fix/log-file: don't delay the file-name-transformation logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
 language: rust
 rust:
   - stable
-  - nightly-2016-12-19
+  - nightly-2017-03-16
 sudo: false
 branches:
   only:
@@ -21,7 +21,7 @@ before_script:
   - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
       (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt;
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-      clippy_vers=0.0.104;
+      clippy_vers=0.0.120;
       if ! cargo clippy --version | grep -q $clippy_vers; then
         cargo install clippy --vers=$clippy_vers --force;
       fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ extern crate bincode;
 extern crate config_file_handler;
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate log as logger;
 extern crate log4rs;
 #[macro_use]

--- a/src/serialisation.rs
+++ b/src/serialisation.rs
@@ -156,7 +156,7 @@ mod tests {
         let mut original_data = (1u64..8).collect::<Vec<_>>();
         let mut serialised_data = unwrap!(serialise_with_limit(&original_data, upper_limit));
         let mut deserialised_data: Vec<u64> = unwrap!(deserialise(&serialised_data));
-        assert!(original_data == deserialised_data);
+        assert_eq!(original_data, deserialised_data);
 
         serialised_data.clear();
         unwrap!(serialise_into_with_limit(&original_data, &mut serialised_data, upper_limit));


### PR DESCRIPTION
Also fix ci for updated rustc and clippy versions according to latest QA Style Guide.

Fixes #85 