### PR TITLE
chore/ci: Allow failures on nightly for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ language: rust
 rust:
   - 1.28.0
   - nightly-2018-07-07
+matrix:
+    allow_failures:
+      - rust: nightly-2018-07-07
 sudo: false
 branches:
   only:


### PR DESCRIPTION
clippy and rustfmt stopped compiling due to an issue with their
proc_macro dependency.

Stop running on nightly for now as we don't have the bandwidth to jump
through so many hoops as work must get done.