### PR TITLE
bump url crate version to 1.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ regex = "~0.2.2"
 serde = "~1.0.25"
 serde-value = "~0.5.1"
 unwrap = "~1.2.0"
-url = "~1.5.1"
+url = "~1.7"
 ws = "~0.7.3"
 
 [features]


### PR DESCRIPTION
bump url crate to version 1.7. cargo test passed. any reason to keep crate url at version ~1.5?

Edit: My apologies for spamming the version bump. didn't realize somebody already did it [here](https://github.com/maidsafe/maidsafe_utilities/pull/137)