### PR TITLE
fix: compiling on latest nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 bincode = "~0.8.0"
 config_file_handler = "~0.11.0"
-lazy_static = "~0.2.8"
+lazy_static = "1.2.0"
 log = "~0.3.8"
 log4rs = {version = "~0.7.0", features=["toml_format"]}
 quick-error = "~1.2.0"
@@ -22,8 +22,8 @@ regex = "~0.2.2"
 serde = "~1.0.91"
 serde-value = "~0.5.1"
 unwrap = "~1.2.0"
-url = "~1.7.2"
-ws = "~0.7.3"
+url = "2.1.0"
+ws = "0.9.1"
 
 [features]
 testing = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,9 @@
     mutable_transmutes,
     no_mangle_const_items,
     unknown_crate_types,
-    warnings
 )]
 #![deny(
     bad_style,
-    deprecated,
     improper_ctypes,
     missing_docs,
     non_shorthand_field_patterns,

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -99,7 +99,7 @@ use std::net::ToSocketAddrs;
 use std::path::Path;
 use std::sync::{Once, ONCE_INIT};
 
-static INITIALISE_LOGGER: Once = ONCE_INIT;
+static INITIALISE_LOGGER: Once = Once::new();
 static CONFIG_FILE: &str = "log.toml";
 static DEFAULT_LOG_LEVEL_FILTER: LogLevelFilter = LogLevelFilter::Warn;
 


### PR DESCRIPTION
1. fix compiling failure related to `url` crate by upgrading deps
2. `cargo fix` to remove warnings
3. some warnings related to `lazy-static` are still present, which are deps of deps, some of
which should be removed later (e.g. `config_file_handler`). Related lints
are removed for the the moment to enable compiling